### PR TITLE
Fix goroutine leak

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -17,9 +17,10 @@
   revision = "5215b55f46b2b919f50a1df0eaa5886afe4e3b3d"
 
 [[projects]]
+  branch = "master"
   name = "github.com/philipjkim/fastimage"
   packages = ["."]
-  revision = "f67c6a4c532a3521ca1ae51a09d3f8a253357ad8"
+  revision = "13c3aa766804edf75ff11d5872d8225f21227cd3"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -43,6 +44,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "75c0f535484009966b7791d7998306b1c0b4f186a28e128e4c042a104eef894c"
+  inputs-digest = "6b254b7532d695f2d842e55792fae0080fec05e4427b2a8d52386e9edf9f5e98"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,7 +20,7 @@
   branch = "master"
   name = "github.com/philipjkim/fastimage"
   packages = ["."]
-  revision = "13c3aa766804edf75ff11d5872d8225f21227cd3"
+  revision = "1487d807c433bccc22f5be7c4bbe32db49cd684e"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,6 +24,9 @@
 #   go-tests = true
 #   unused-packages = true
 
+[[constraint]]
+  name = "github.com/philipjkim/fastimage"
+  branch = "master"
 
 [prune]
   go-tests = true

--- a/readability.go
+++ b/readability.go
@@ -679,7 +679,7 @@ func images(doc *goquery.Document, reqURL string, opt *Option) []Image {
 		go func(lc *uint) {
 			defer func() {
 				if err := recover(); err != nil {
-					fmt.Printf("checkImageSize failed for %v: %v\n", src, err)
+					fmt.Printf("[readability] checkImageSize failed for %v: %v\n", src, err)
 				}
 			}()
 
@@ -702,6 +702,8 @@ func images(doc *goquery.Document, reqURL string, opt *Option) []Image {
 				return imgs
 			}
 		case <-timeout:
+			fmt.Printf("[readability] checkImageSize timed out: reqURL: %s\n", reqURL)
+			close(ch)
 			return imgs
 		}
 	}

--- a/readability.go
+++ b/readability.go
@@ -681,7 +681,10 @@ func images(doc *goquery.Document, reqURL string, opt *Option) []Image {
 		go func(lc *uint) {
 			defer func() {
 				if err := recover(); err != nil {
-					fmt.Printf("[readability] checkImageSize failed for %v: %v\n", src, err)
+					if isVerbose() {
+						fmt.Printf("[readability] checkImageSize failed for %v: %v\n",
+							src, err)
+					}
 				}
 			}()
 
@@ -704,7 +707,9 @@ func images(doc *goquery.Document, reqURL string, opt *Option) []Image {
 				return imgs
 			}
 		case <-timeout:
-			fmt.Printf("[readability] checkImageSize timed out: reqURL: %s\n", reqURL)
+			if isVerbose() {
+				fmt.Printf("[readability] checkImageSize timed out: reqURL: %s\n", reqURL)
+			}
 			return imgs
 		}
 	}

--- a/readability.go
+++ b/readability.go
@@ -728,7 +728,7 @@ func checkImageSize(src string, widthFromAttr, heightFromAttr int, opt *Option, 
 	width, height := widthFromAttr, heightFromAttr
 	if width == 0 || height == 0 {
 		*loopCnt++
-		_, size, err := fastimage.DetectImageTypeWithTimeout2(src, opt.ImageRequestTimeout)
+		_, size, err := fastimage.DetectImageTypeWithTimeout(src, opt.ImageRequestTimeout)
 		if isVerbose() {
 			fmt.Printf("[req] loopCnt: %v, src: %v, err: %v, size: %v\n",
 				*loopCnt, src, err, size)

--- a/readability.go
+++ b/readability.go
@@ -656,6 +656,8 @@ func sortCandidates(candidates map[string]candidate) candidateList {
 
 func images(doc *goquery.Document, reqURL string, opt *Option) []Image {
 	ch := make(chan *Image)
+	defer close(ch)
+
 	imgs := []Image{}
 	loopCnt := uint(0)
 	doc.Find("img").EachWithBreak(func(i int, s *goquery.Selection) bool {
@@ -703,7 +705,6 @@ func images(doc *goquery.Document, reqURL string, opt *Option) []Image {
 			}
 		case <-timeout:
 			fmt.Printf("[readability] checkImageSize timed out: reqURL: %s\n", reqURL)
-			close(ch)
 			return imgs
 		}
 	}

--- a/readability.go
+++ b/readability.go
@@ -722,7 +722,7 @@ func checkImageSize(src string, widthFromAttr, heightFromAttr int, opt *Option, 
 	width, height := widthFromAttr, heightFromAttr
 	if width == 0 || height == 0 {
 		*loopCnt++
-		_, size, err := fastimage.DetectImageTypeWithTimeout(src, opt.ImageRequestTimeout)
+		_, size, err := fastimage.DetectImageTypeWithTimeout2(src, opt.ImageRequestTimeout)
 		if isVerbose() {
 			fmt.Printf("[req] loopCnt: %v, src: %v, err: %v, size: %v\n",
 				*loopCnt, src, err, size)

--- a/vendor/github.com/philipjkim/fastimage/.gitignore
+++ b/vendor/github.com/philipjkim/fastimage/.gitignore
@@ -3,6 +3,8 @@
 *.a
 *.so
 
+*.log
+
 # Folders
 _obj
 _test

--- a/vendor/github.com/philipjkim/fastimage/fastimage.go
+++ b/vendor/github.com/philipjkim/fastimage/fastimage.go
@@ -2,7 +2,6 @@ package fastimage
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"net/http"
 	"time"
@@ -27,14 +26,13 @@ func DetectImageType(uri string) (ImageType, *ImageSize, error) {
 // If timeout < 1, default timeout 5000 is used.
 func DetectImageTypeWithTimeout(uri string, timeout uint) (ImageType, *ImageSize, error) {
 	logger.Printf("Opening HTTP stream")
-	t := time.Duration(timeout) * time.Millisecond
-	client := &http.Client{Timeout: t}
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Millisecond,
+	}
 	resp, err := client.Get(uri)
-
 	if err != nil {
 		return Unknown, nil, err
 	}
-
 	defer closeHTTPStream(resp)
 
 	return DetectImageTypeFromResponse(resp)
@@ -48,71 +46,45 @@ func DetectImageTypeWithTimeout(uri string, timeout uint) (ImageType, *ImageSize
 // Only check ImageType and ImageSize if error is not nil.
 func DetectImageTypeFromResponse(resp *http.Response) (ImageType, *ImageSize, error) {
 	logger.Printf("Response content-length: %v bytes", resp.ContentLength)
-
 	return DetectImageTypeFromReader(resp.Body)
-
 }
 
 // DetectImageTypeFromReader detects the type and size from a stream of bytes.
 //
 // Only check ImageType and ImageSize if error is not nil.
 func DetectImageTypeFromReader(r io.Reader) (ImageType, *ImageSize, error) {
-	type imageInfo struct {
-		itype ImageType
-		isize *ImageSize
-		err   error
-	}
+	buffer := bytes.Buffer{}
 
-	ch := make(chan imageInfo)
+	logger.Printf("Starting operation")
+	defer logger.Printf("Ended after reading %v bytes", buffer.Len())
 
-	quit := false
-	go func() {
-		buffer := bytes.Buffer{}
+	for {
+		err := readToBuffer(r, &buffer)
+		if err != nil {
+			logger.Printf("Bailing out because of err %v", err)
+			return Unknown, nil, err
+		}
 
-		logger.Printf("Starting operation")
-		defer logger.Printf("Ended after reading %v bytes", buffer.Len())
+		if buffer.Len() < 2 {
+			continue
+		}
+		if buffer.Len() > 20000 {
+			logger.Println("Type not found until buffer read exceeds 20000 bytes")
+			return Unknown, nil, err
+		}
 
-		for {
-			if quit {
-				logger.Println("Quit signal received in DetectImageTypeFromReader")
-				return
-			}
-			err := readToBuffer(r, &buffer)
-			if buffer.Len() < 2 {
-				continue
-			}
+		for _, ImageTypeParser := range imageTypeParsers {
+			if ImageTypeParser.Detect(buffer.Bytes()) {
+				t := ImageTypeParser.Type()
+				size, err := ImageTypeParser.GetSize(buffer.Bytes())
 
-			if err != nil {
-				logger.Printf("Bailing out because of err %v", err)
-				ch <- imageInfo{Unknown, nil, err}
-				return
-			}
-
-			for _, ImageTypeParser := range imageTypeParsers {
-				if ImageTypeParser.Detect(buffer.Bytes()) {
-					t := ImageTypeParser.Type()
-					size, err := ImageTypeParser.GetSize(buffer.Bytes())
-
-					if err == nil {
-						logger.Printf("Found image type %v with size %v", t, size)
-						ch <- imageInfo{t, size, nil}
-						return
-					}
-					break
+				if err == nil {
+					logger.Printf("Found image type %v with size %v", t, size)
+					return t, size, nil
 				}
+				break
 			}
 		}
-	}()
-
-	timedOut := time.After(time.Duration(500) * time.Millisecond)
-	select {
-	case ii := <-ch:
-		quit = true
-		return ii.itype, ii.isize, ii.err
-	case <-timedOut:
-		logger.Println("Timeout in DetectImageTypeFromReader")
-		quit = true
-		return Unknown, nil, errors.New("Timeout in DetectImageTypeFromReader")
 	}
 }
 

--- a/vendor/github.com/philipjkim/fastimage/fastimage.go
+++ b/vendor/github.com/philipjkim/fastimage/fastimage.go
@@ -2,6 +2,7 @@ package fastimage
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net/http"
 	"time"
@@ -83,6 +84,68 @@ func DetectImageTypeFromReader(r io.Reader) (ImageType, *ImageSize, error) {
 					return t, size, nil
 				}
 				break
+			}
+		}
+	}
+}
+
+// DetectImageTypeWithTimeout2 acts same as DetectImageTypeWithTimeout(),
+// except this function cancels detection logic
+// if elapsed time exceeds 500ms.
+//
+// If timeout < 1, default timeout 5000 is used.
+func DetectImageTypeWithTimeout2(uri string, timeout uint) (ImageType, *ImageSize, error) {
+	logger.Printf("Opening HTTP stream")
+	client := &http.Client{
+		Timeout: time.Duration(timeout) * time.Millisecond,
+	}
+	resp, err := client.Get(uri)
+	if err != nil {
+		return Unknown, nil, err
+	}
+	defer closeHTTPStream(resp)
+
+	logger.Printf("Response content-length: %v bytes", resp.ContentLength)
+	buffer := bytes.Buffer{}
+
+	logger.Printf("Starting operation")
+	defer logger.Printf("Ended after reading %v bytes", buffer.Len())
+
+	parseTimeout := time.After(500 * time.Millisecond)
+
+	for {
+		select {
+		case <-parseTimeout:
+			err := fmt.Errorf("Image type detection timeout: url: %s", uri)
+			fmt.Println("[fastimage] " + err.Error())
+			return Unknown, nil, err
+		default:
+			err := readToBuffer(resp.Body, &buffer)
+			if err != nil {
+				logger.Printf("Bailing out because of err %v", err)
+				return Unknown, nil, err
+			}
+
+			if buffer.Len() < 2 {
+				continue
+			}
+			if buffer.Len() > 20000 {
+				err = fmt.Errorf("Type not found until buffer read exceeds 20000 bytes")
+				logger.Println(err.Error())
+				return Unknown, nil, err
+			}
+
+			for _, ImageTypeParser := range imageTypeParsers {
+				if ImageTypeParser.Detect(buffer.Bytes()) {
+					t := ImageTypeParser.Type()
+					size, err := ImageTypeParser.GetSize(buffer.Bytes())
+
+					if err == nil {
+						logger.Printf("Found image type %v with size %v", t, size)
+						return t, size, nil
+					}
+					break
+				}
 			}
 		}
 	}

--- a/vendor/github.com/philipjkim/fastimage/util.go
+++ b/vendor/github.com/philipjkim/fastimage/util.go
@@ -1,8 +1,10 @@
 package fastimage
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/binary"
+	"os"
 )
 
 func readUint16(buffer []byte) (result uint16) {
@@ -15,4 +17,18 @@ func readULint16(buffer []byte) (result uint16) {
 	reader := bytes.NewReader(buffer)
 	binary.Read(reader, binary.LittleEndian, &result)
 	return
+}
+
+func readSampleFile(sf string) ([]string, error) {
+	f, err := os.Open(sf)
+	if err != nil {
+		return nil, err
+	}
+	fs := bufio.NewScanner(f)
+	var images []string
+	for fs.Scan() {
+		images = append(images, fs.Text())
+	}
+
+	return images, nil
 }


### PR DESCRIPTION
Explicitly close open channel before exiting `images(doc, reqURL, opt)` function, since some goroutines created inside the function never finishes with `chan send` status:

```
# investigated using pprof.Lookup("goroutine")

goroutine 155785 [chan send, 5 minutes]:
github.com/philipjkim/goreadability.images.func1.1(0xc45cc4f030, 0x62, 0xc452d56ea0, 0x23, 0x23, 0xd9e780, 0xc452d65120)
	/go/src/github.com/philipjkim/goreadability/readability.go:686 +0xb6
created by github.com/philipjkim/goreadability.images.func1
	/go/src/github.com/philipjkim/goreadability/readability.go:679 +0x291
```